### PR TITLE
Fixed Menu ID issue - original ID did not exist

### DIFF
--- a/getDirectionGoogleMap/src/com/DJAndroid/getDirection/AbstractMapActivity.java
+++ b/getDirectionGoogleMap/src/com/DJAndroid/getDirection/AbstractMapActivity.java
@@ -18,7 +18,7 @@ public class AbstractMapActivity extends SherlockFragmentActivity {
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
-		getSupportMenuInflater().inflate(R.menu.activity_main, menu);
+		getSupportMenuInflater().inflate(R.menu.main, menu);
 
 		return (super.onCreateOptionsMenu(menu));
 	}


### PR DESCRIPTION
Looks like your original ID was referring the Main layout instead your Menu XML.

Great example by the way!
